### PR TITLE
Unpin ccxt, weekly schedule

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -11,7 +11,10 @@ update: all
 # allowed: True, False
 pin: True
 
-schedule: "every day"
+# update schedule
+# default: empty
+# allowed: "every day", "every week", ..
+schedule: "every week"
 
 # search for requirement files
 # default: True

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ TA-Lib==0.4.17
 pyti==0.2.2
 pandas==0.24.2
 simplejson==3.16.0
-ccxt==1.18.523
+ccxt>=1.18.500
 arrow==0.13.1
 SQLAlchemy==1.3.3
 # keras


### PR DESCRIPTION
As mentioned in https://github.com/freqtrade/freqtrade/issues/1849 - we should only update weekly.

I've also (partially) unpinned ccxt, since that updates quite frequently, and we need to be carefull to not get misalligned dependencies with freqtrade.