### PR TITLE
Copy indicator_helper.py from main freqtrade repo

### DIFF
--- a/technical/indicator_helpers.py
+++ b/technical/indicator_helpers.py
@@ -1,0 +1,40 @@
+from math import cos, exp, pi, sqrt
+
+import numpy as np
+import talib as ta
+from pandas import Series
+
+
+def went_up(series: Series) -> bool:
+    return series > series.shift(1)
+
+
+def went_down(series: Series) -> bool:
+    return series < series.shift(1)
+
+
+def ehlers_super_smoother(series: Series, smoothing: float = 6) -> Series:
+    magic = pi * sqrt(2) / smoothing
+    a1 = exp(-magic)
+    coeff2 = 2 * a1 * cos(magic)
+    coeff3 = -a1 * a1
+    coeff1 = (1 - coeff2 - coeff3) / 2
+
+    filtered = series.copy()
+
+    for i in range(2, len(series)):
+        filtered.iloc[i] = coeff1 * (series.iloc[i] + series.iloc[i-1]) + \
+            coeff2 * filtered.iloc[i-1] + coeff3 * filtered.iloc[i-2]
+
+    return filtered
+
+
+def fishers_inverse(series: Series, smoothing: float = 0) -> np.ndarray:
+    """ Does a smoothed fishers inverse transformation.
+        Can be used with any oscillator that goes from 0 to 100 like RSI or MFI """
+    v1 = 0.1 * (series - 50)
+    if smoothing > 0:
+        v2 = ta.WMA(v1.values, timeperiod=smoothing)
+    else:
+        v2 = v1
+    return (np.exp(2 * v2)-1) / (np.exp(2 * v2) + 1)

--- a/technical/tests/test_indicator_helpers.py
+++ b/technical/tests/test_indicator_helpers.py
@@ -1,0 +1,15 @@
+# pragma pylint: disable=missing-docstring
+
+import pandas as pd
+
+from freqtrade.indicator_helpers import went_down, went_up
+
+
+def test_went_up():
+    series = pd.Series([1, 2, 3, 1])
+    assert went_up(series).equals(pd.Series([False, True, True, False]))
+
+
+def test_went_down():
+    series = pd.Series([1, 2, 3, 1])
+    assert went_down(series).equals(pd.Series([False, False, False, True]))

--- a/technical/tests/test_indicator_helpers.py
+++ b/technical/tests/test_indicator_helpers.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 
-from freqtrade.indicator_helpers import went_down, went_up
+from technical.indicator_helpers import went_down, went_up
 
 
 def test_went_up():


### PR DESCRIPTION
... in order to remove it in the main freqtrade repo, it's no longer used in the DefaultStrategy (and in the user_data as well; same for freqtrade/freqtrade-strategies)

TODO:
- [x] copy the test (forgotten)