### PR TITLE
fix Resampled_merge shift bug

### DIFF
--- a/technical/util.py
+++ b/technical/util.py
@@ -1,7 +1,7 @@
 """
     defines utility functions to be used
 """
-from pandas import DatetimeIndex, merge, DataFrame, to_datetime, DateOffset
+from pandas import DatetimeIndex, merge, DataFrame, to_datetime
 
 from technical.exchange import TICKER_INTERVAL_MINUTES
 
@@ -72,7 +72,6 @@ def resampled_merge(original, resampled, fill_na=False):
     :return: the merged dataset
     """
 
-    interval = int((original['date'] - original['date'].shift()).min().total_seconds() // 60)
     resampled_interval = compute_interval(resampled)
 
     # no point in interpolating these colums
@@ -86,7 +85,7 @@ def resampled_merge(original, resampled, fill_na=False):
     # drop columns which should not be joined
     resampled = resampled.drop(columns=['open', 'high', 'low', 'close'])
 
-    resampled['date'] = resampled.index - DateOffset(minutes=interval)
+    resampled['date'] = resampled.index
     resampled.index = range(len(resampled))
     dataframe = merge(original, resampled, on='date', how='left')
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -32,6 +32,11 @@ def test_resampled_merge(testdata_1m_btc):
 
     assert "resample_5_date" not in merged
     assert "resample_5_volume" not in merged
+    # Verify the assignment goes to the correct candle
+    # If resampling to 5m, then the resampled value needs to be on the 5m candle.
+    assert sum(merged.loc[merged['date'] == '2017-11-14 22:54:00', 'resample_5_close'].isna()) == 1
+    assert sum(merged.loc[merged['date'] == '2017-11-14 22:55:00', 'resample_5_close'].isna()) == 0
+    assert sum(merged.loc[merged['date'] == '2017-11-14 22:56:00', 'resample_5_close'].isna()) == 1
 
 
 def test_resampled_merge_contains_indicator(testdata_1m_btc):


### PR DESCRIPTION
Currently, resampled_merge shifts all resampled values to the wrong candle.

e.g. Resample to 1D, and merge back to 1h:
First "new" value is at 23:00 - instead of 00:00.

Example picture (taken from #60)

![resampled](https://user-images.githubusercontent.com/58388876/72683037-10f21600-3ad4-11ea-93a0-09ad1e95bcfd.png)

The "shift -interval" is unnecessary and 

closes #60