### PR TITLE
fix HA-open calculations

### DIFF
--- a/technical/candles.py
+++ b/technical/candles.py
@@ -8,11 +8,9 @@ def heikinashi(bars):
     bars['ha_close'] = (bars['open'] + bars['high'] +
                         bars['low'] + bars['close']) / 4
 
-    bars['ha_open'] = (bars['open'].shift(1) + bars['close'].shift(1)) / 2
-    bars.loc[:1, 'ha_open'] = bars['open'].values[0]
-    for x in range(2):
-        bars.loc[1:, 'ha_open'] = (
-                                          (bars['ha_open'].shift(1) + bars['ha_close'].shift(1)) / 2)[1:]
+    bars.at[0, 'ha_open'] = (bars.at[0, 'open'] + bars.at[0, 'close']) / 2
+    for x in range(1, len(bars)):
+        bars.at[x, 'ha_open'] = (bars.at[x - 1, 'ha_open'] + bars.at[x - 1, 'ha_close']) / 2
 
     bars['ha_high'] = bars.loc[:, ['high', 'ha_open', 'ha_close']].max(axis=1)
     bars['ha_low'] = bars.loc[:, ['low', 'ha_open', 'ha_close']].min(axis=1)


### PR DESCRIPTION
As discussed in: https://github.com/freqtrade/technical/issues/152

A few more changes were needed. The original for loop was only running 2 times. And line 11 in original file was not needed.

I tested the change with a dry test:
```python
dataframe['freqtrade_ha_open'] = heikinashi(dataframe)['open']
dataframe['freqtrade_ha_high'] = heikinashi(dataframe)['high']
dataframe['freqtrade_ha_low'] = heikinashi(dataframe)['low']
dataframe['freqtrade_ha_close'] = heikinashi(dataframe)['close']

dataframe['qtpylib_ha_open'] = qtpylib.heikinashi(dataframe)['open']
dataframe['qtpylib_ha_high'] = qtpylib.heikinashi(dataframe)['high']
dataframe['qtpylib_ha_low'] = qtpylib.heikinashi(dataframe)['low']
dataframe['qtpylib_ha_close'] = qtpylib.heikinashi(dataframe)['close']

dataframe['diff_ha_open'] = dataframe['freqtrade_ha_open'] - dataframe['qtpylib_ha_open']
dataframe['diff_ha_high'] = dataframe['freqtrade_ha_high'] - dataframe['qtpylib_ha_high']
dataframe['diff_ha_low'] = dataframe['freqtrade_ha_low'] - dataframe['qtpylib_ha_low']
dataframe['diff_ha_close'] = dataframe['freqtrade_ha_close'] - dataframe['qtpylib_ha_close']

dataframe['qtpylib_ha_green_to_red'] = qtpylib.crossed_below(dataframe['qtpylib_ha_close'], dataframe['qtpylib_ha_open'])
dataframe['qtpylib_ha_red_to_green'] = qtpylib.crossed_above(dataframe['qtpylib_ha_close'], dataframe['qtpylib_ha_open'])

dataframe['freqtrade_ha_reversal'] = heikinashi(dataframe)['reversal']

dataframe.to_csv('user_data/HA-test-{}.csv'.format(metadata['pair'].replace("/","-")))
```
I calculated the difference between Freqtrade and QTPyLib in: dataframe['diff_ha_open'],  dataframe['diff_ha_high'], dataframe['diff_ha_low'], dataframe['diff_ha_close'], and those should all be 0.

This was dataframe before the changes with many differences:
[HA-test-AAVE-USDT-before.xlsx](https://github.com/freqtrade/technical/files/5941722/HA-test-AAVE-USDT-before.xlsx)

And this is the dataframe after changes where the differences are all 0:
[HA-test-AAVE-USDT-after.xlsx](https://github.com/freqtrade/technical/files/5941723/HA-test-AAVE-USDT-after.xlsx)
