### PR TITLE
Remove `aroon` in favor of ta.AROON

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ The following indicators are available and have been 'wrapped' to be used on a d
 * [chaikin_money_flow](https://www.tradingview.com/wiki/Chaikin_Money_Flow_(CMF)) - Chaikin Money Flow, requires dataframe and period
 * [accumulation_distribution](https://www.investopedia.com/terms/a/accumulationdistribution.asp) - requires a dataframe
 * osc - requires a dataframe and the periods
-* [aroon](https://www.investopedia.com/terms/a/aroon.asp) - dataframe, period, field
 * [atr](https://www.investopedia.com/terms/a/atr.asp) - dataframe, period, field
 * [atr_percent](https://www.investopedia.com/terms/a/atr.asp) - dataframe, period, field
 * [bollinger_bands](https://www.investopedia.com/terms/b/bollingerbands.asp) - dataframe, period, stdv, field, prefix
@@ -85,7 +84,7 @@ dataframe_long['rsi'] = ta.RSI(dataframe_long)
 dataframe = resampled_merge(dataframe, dataframe_long, fill_na=True)
 
 """
-The resulting dataframe will have 5 resampled columns in addition to the regular columns, 
+The resulting dataframe will have 5 resampled columns in addition to the regular columns,
 following the template resample_<interval_in_minutes>_<orig_column_name>.
 So in the above example:
 ['resample_240_open', 'resample_240_high', 'resample_240_low','resample_240_close', 'resample_240_rsi']

--- a/technical/indicators/momentum.py
+++ b/technical/indicators/momentum.py
@@ -15,16 +15,6 @@ from pandas import DataFrame
 # ADXR                 Average Directional Movement Index Rating
 # APO                  Absolute Price Oscillator
 
-# AROON                Aroon
-def aroon(dataframe, period=25, field='close', colum_prefix="aroon") -> DataFrame:
-    from pyti.aroon import aroon_up as up
-    from pyti.aroon import aroon_down as down
-    dataframe["{}_up".format(colum_prefix)] = up(dataframe[field], period)
-    dataframe["{}_down".format(colum_prefix)] = down(dataframe[field], period)
-    return dataframe
-
-
-# AROONOSC             Aroon Oscillator
 # BOP                  Balance Of Power
 
 # CCI                  Commodity Channel Index

--- a/technical/indicators/momentum.py
+++ b/technical/indicators/momentum.py
@@ -3,7 +3,6 @@ Momentum indicators
 """
 
 from numpy.core.records import ndarray
-from pandas import DataFrame
 
 
 ########################################
@@ -14,7 +13,8 @@ from pandas import DataFrame
 # ADX                  Average Directional Movement Index
 # ADXR                 Average Directional Movement Index Rating
 # APO                  Absolute Price Oscillator
-
+# AROON                Aroon
+# AROONOSC             Aroon Oscillator
 # BOP                  Balance Of Power
 
 # CCI                  Commodity Channel Index

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -2,18 +2,6 @@ import numpy
 import pytest
 
 
-@pytest.mark.skip(reason="this fails right now")
-def test_arron(testdata_1m_btc):
-    from technical.indicators import aroon
-
-    print()
-    print(testdata_1m_btc)
-
-    result = aroon(testdata_1m_btc)
-
-    print(result)
-
-
 def test_atr(testdata_1m_btc):
     from technical.indicators import atr
 


### PR DESCRIPTION
Hi,

I propose to remove `aroon` from technical.

Reasons:
1. It's included in TA and is already used in the sample_strategy over at freqtrade: https://github.com/freqtrade/freqtrade/blob/4cb67f140a8b469a9ace13e473811b3b25d62993/freqtrade/templates/sample_strategy.py#L138
2. It's erroring out when using with something like `0 is not a range`
3. and it also seems to be disabled in ci-test (maybe because of that): https://github.com/freqtrade/technical/blob/daa2facae2aa35f9cb0e3dcf141155c52f50c51d/tests/test_indicators.py#L5

I know it would have saved me a few hours, maybe it helps somebody else as well.