### PR TITLE
Correction of Bollinger Bands standard deviation

### DIFF
--- a/technical/indicators/overlap_studies.py
+++ b/technical/indicators/overlap_studies.py
@@ -20,7 +20,7 @@ def bollinger_bands(dataframe: DataFrame, period: int = 21, stdv: int = 2,
         <column_prefix>_lower, <column_prefix>_middle, and <column_prefix>_upper,
     """
     rolling_mean = dataframe[field].rolling(window=period).mean()
-    rolling_std = dataframe[field].rolling(window=period).std()
+    rolling_std = dataframe[field].rolling(window=period).std(ddof=0)
     dataframe[f"{colum_prefix}_lower"] = rolling_mean - (rolling_std * stdv)
     dataframe[f"{colum_prefix}_middle"] = rolling_mean
     dataframe[f"{colum_prefix}_upper"] = rolling_mean + (rolling_std * stdv)


### PR DESCRIPTION
- Bollinger Bands should use the "population standard deviation" for the calculation of the standard deviation, see 4th paragraph: https://www.bollingerbands.com/bollinger-bands
- But default for the pandas standard deviation is the "sample standard deviation"
- Further explanation about the 2 different methods: https://towardsdatascience.com/why-computing-standard-deviation-in-pandas-and-numpy-yields-different-results-5b475e02d112
- Also TA-Lib uses population standard deviation