### PR TITLE
Fixed highest_high and lowest_low on williams_percent.

### DIFF
--- a/technical/indicators/momentum.py
+++ b/technical/indicators/momentum.py
@@ -65,7 +65,7 @@ def ultimate_oscilator(dataframe):
 
 # WILLR                Williams' %R
 def williams_percent(dataframe, period=14, field='close'):
-    highest_high = dataframe[field].rolling(period).max()
-    lowest_low = dataframe[field].rolling(period).min()
+    highest_high = dataframe['high'].rolling(period).max()
+    lowest_low = dataframe['low'].rolling(period).min()
     wr = (highest_high - dataframe[field]) / (highest_high - lowest_low) * -100
     return wr

--- a/technical/indicators/momentum.py
+++ b/technical/indicators/momentum.py
@@ -64,8 +64,8 @@ def ultimate_oscilator(dataframe):
 
 
 # WILLR                Williams' %R
-def williams_percent(dataframe, period=14, field='close'):
+def williams_percent(dataframe, period=14):
     highest_high = dataframe['high'].rolling(period).max()
     lowest_low = dataframe['low'].rolling(period).min()
-    wr = (highest_high - dataframe[field]) / (highest_high - lowest_low) * -100
+    wr = (highest_high - dataframe['close']) / (highest_high - lowest_low) * -100
     return wr


### PR DESCRIPTION
Previous implementation used the "field" parameter to calculate, defaulting to close. This didn't align with the definition of [Williams %R](https://www.investopedia.com/terms/w/williamsr.asp).