### PR TITLE
Remove pyti

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,5 @@
 TA-Lib==0.4.19
 pyti==0.2.2
 pandas==1.2.3
-ccxt>=1.18.500
 arrow==1.0.3
-# keras
 # matplotlib
-# tensorflow - install if no gpu
-# tensorflow-gpu - install if gpu

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 TA-Lib==0.4.19
-pyti==0.2.2
 pandas==1.2.3
 arrow==1.0.3
 # matplotlib

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(name='technical',
       tests_require=['pytest', 'pytest-cov', 'pytest-mock'],
       install_requires=[
           'TA-Lib',
-          'pyti',
           'pandas',
           'arrow',
       ],

--- a/technical/consensus/consensus.py
+++ b/technical/consensus/consensus.py
@@ -450,12 +450,11 @@ class Consensus:
         :param prefix:
         :return:
         """
-        from technical.indicators import cci
 
         self._weights(impact_buy, impact_sell)
         dataframe = self.dataframe
         name = '{}_{}'.format(prefix, period)
-        dataframe[name] = cci(dataframe, period)
+        dataframe[name] = ta.CCI(dataframe, timeperiod=period)
 
         dataframe.loc[
             (
@@ -539,12 +538,10 @@ class Consensus:
         :param prefix:
         :return:
         """
-        from technical.indicators import cmo
-
         self._weights(impact_buy, impact_sell)
         dataframe = self.dataframe
         name = '{}_{}'.format(prefix, period)
-        dataframe[name] = cmo(dataframe, period)
+        dataframe[name] = ta.CMO(dataframe, timeperiod=period)
 
         dataframe.loc[
             (
@@ -608,12 +605,10 @@ class Consensus:
         :param prefix:
         :return:
         """
-        from technical.indicators import ultimate_oscilator
-
         self._weights(impact_buy, impact_sell)
         dataframe = self.dataframe
         name = '{}'.format(prefix)
-        dataframe[name] = ultimate_oscilator(dataframe)
+        dataframe[name] = ta.ULTOSC(dataframe)
 
         dataframe.loc[
             (
@@ -666,12 +661,11 @@ class Consensus:
         :param prefix:
         :return:
         """
-        from technical.indicators import momentum
 
         self._weights(impact_buy, impact_sell)
         dataframe = self.dataframe
         name = '{}_{}'.format(prefix, period)
-        dataframe[name] = momentum(dataframe, 'close', period)
+        dataframe[name] = ta.MOM(dataframe, timeperiod=period)
 
         dataframe.loc[
             (

--- a/technical/indicators/indicators.py
+++ b/technical/indicators/indicators.py
@@ -617,7 +617,6 @@ def vfi(dataframe, length=130, coef=0.2, vcoef=2.5, signalLength=5, smoothVFI=Fa
 
     import talib as ta
     from numpy import where
-    from pyti.simple_moving_average import simple_moving_average as sma
 
     length = length
     coef = coef
@@ -631,7 +630,7 @@ def vfi(dataframe, length=130, coef=0.2, vcoef=2.5, signalLength=5, smoothVFI=Fa
     df['vinter'] = df['inter'].rolling(30).std(ddof=0)
     df['cutoff'] = (coef * df['vinter'] * df['close'])
     # Vave is to be calculated on volume of the past bar
-    df['vave'] = sma(df['volume'].shift(+1), length)
+    df['vave'] = ta.SMA(df['volume'].shift(+1), timeperiod=length)
     df['vmax'] = df['vave'] * vcoef
     df['vc'] = where((df['volume'] < df['vmax']), df['volume'], df['vmax'])
     df['mf'] = df['hlc'] - df['hlc'].shift(+1)
@@ -649,7 +648,7 @@ def vfi(dataframe, length=130, coef=0.2, vcoef=2.5, signalLength=5, smoothVFI=Fa
     # vfi has a smooth option passed over def call, sma if set
     df['vfi'] = (df['vcp'].rolling(length).sum()) / df['vave']
     if smoothVFI is True:
-        df['vfi'] = sma(df['vfi'], 3)
+        df['vfi'] = ta.SMA(df['vfi'], timeperiod=3)
     df['vfima'] = ta.EMA(df['vfi'], signalLength)
     df['vfi_hist'] = df['vfi'] - df['vfima']
 

--- a/technical/indicators/momentum.py
+++ b/technical/indicators/momentum.py
@@ -18,17 +18,8 @@ from numpy.core.records import ndarray
 # BOP                  Balance Of Power
 
 # CCI                  Commodity Channel Index
-def cci(dataframe, period) -> ndarray:
-    from pyti.commodity_channel_index import commodity_channel_index
-
-    return commodity_channel_index(dataframe['close'], dataframe['high'], dataframe['low'], period)
-
 
 # CMO                  Chande Momentum Oscillator
-def cmo(dataframe, period, field='close') -> ndarray:
-    from pyti.chande_momentum_oscillator import chande_momentum_oscillator
-    return chande_momentum_oscillator(dataframe[field], period)
-
 
 # DX                   Directional Movement Index
 # MACD                 Moving Average Convergence/Divergence
@@ -39,10 +30,6 @@ def cmo(dataframe, period, field='close') -> ndarray:
 # MINUS_DM             Minus Directional Movement
 
 # MOM                  Momentum
-def momentum(dataframe, field='close', period=9):
-    from pyti.momentum import momentum as m
-    return m(dataframe[field], period)
-
 
 # PLUS_DI              Plus Directional Indicator
 # PLUS_DM              Plus Directional Movement
@@ -58,9 +45,6 @@ def momentum(dataframe, field='close', period=9):
 # TRIX                 1-day Rate-Of-Change (ROC) of a Triple Smooth EMA
 
 # ULTOSC               Ultimate Oscillator
-def ultimate_oscilator(dataframe):
-    from pyti.ultimate_oscillator import ultimate_oscillator as uo
-    uo(dataframe['close'], dataframe['low'])
 
 
 # WILLR                Williams' %R

--- a/technical/indicators/overlap_studies.py
+++ b/technical/indicators/overlap_studies.py
@@ -68,7 +68,8 @@ def tema(dataframe, period, field='close'):
 
 # Other Overlap Studies Functions
 def hull_moving_average(dataframe, period, field='close') -> ndarray:
-    from pyti.hull_moving_average import hull_moving_average as hma
+    # TODO: Remove this helper method, it's a 1:1 call to qtpylib's HMA.
+    from technical.qtpylib import hma
     return hma(dataframe[field], period)
 
 

--- a/technical/indicators/volume_indicators.py
+++ b/technical/indicators/volume_indicators.py
@@ -12,12 +12,6 @@ from numpy.core.records import ndarray
 
 # AD                   Chaikin A/D Line
 
-def accumulation_distribution(dataframe) -> ndarray:
-    from pyti.accumulation_distribution import accumulation_distribution as acd
-
-    return acd(dataframe['close'], dataframe['high'], dataframe['low'], dataframe['volume'])
-
-
 # ADOSC                Chaikin A/D Oscillator
 # OBV                  On Balance Volume
 


### PR DESCRIPTION
Implicitly closes #166, as it's fixing the "slow" behaviour in consensus by replacing Ultimate Oscillator (UO) with a performant version.

Removes most indicators which call pyti in favor of ta-lib, as the performance of ta-lib is superior to pyti (which uses loops in almost all cases).