### PR TITLE
Resampling: label = left

### DIFF
--- a/technical/util.py
+++ b/technical/util.py
@@ -79,10 +79,10 @@ def resampled_merge(original, resampled, fill_na=False):
 
     resampled_interval = compute_interval(resampled)
 
-    # no point in interpolating these colums
+    # no point in interpolating these columns
     resampled = resampled.drop(columns=["date", "volume"])
 
-    # rename all the colums to the correct interval
+    # rename all the columns to the correct interval
     for header in list(resampled):
         # store the resampled columns in it
         resampled[f"resample_{resampled_interval}_{header}"] = resampled[header]

--- a/technical/util.py
+++ b/technical/util.py
@@ -57,7 +57,7 @@ def resample_to_interval(dataframe, interval):
     """
     if isinstance(interval, str):
         interval = TICKER_INTERVAL_MINUTES[interval]
-    
+
     df = dataframe.copy()
     df = df.set_index(DatetimeIndex(df["date"]))
     ohlc_dict = {"open": "first", "high": "max", "low": "min", "close": "last", "volume": "sum"}
@@ -70,7 +70,7 @@ def resample_to_interval(dataframe, interval):
 def resampled_merge(original, resampled, fill_na=True):
     """
         this method merges a resampled dataset back into the orignal data set.
-        Resampled candle will match OHLC only if full timespan is available in original dataframe. 
+        Resampled candle will match OHLC only if full timespan is available in original dataframe.
 
     :param original: the original non resampled dataset
     :param resampled:  the resampled dataset
@@ -93,7 +93,8 @@ def resampled_merge(original, resampled, fill_na=True):
     # rename all the columns to the correct interval
     resampled.columns = [f"resample_{resampled_int}_{col}" for col in resampled.columns]
 
-    dataframe = merge(original, resampled, left_on='date', right_on=f'resample_{resampled_int}_date_merge', how="left")
+    dataframe = merge(original, resampled, how="left",
+                      left_on='date', right_on=f'resample_{resampled_int}_date_merge')
     dataframe = dataframe.drop(f'resample_{resampled_int}_date_merge', axis=1)
 
     if fill_na:

--- a/technical/util.py
+++ b/technical/util.py
@@ -62,7 +62,7 @@ def resample_to_interval(dataframe, interval):
     df = dataframe.copy()
     df = df.set_index(DatetimeIndex(df["date"]))
     ohlc_dict = {"open": "first", "high": "max", "low": "min", "close": "last", "volume": "sum"}
-    df = df.resample(str(interval) + "min", label="right").agg(ohlc_dict).dropna()
+    df = df.resample(str(interval) + "min", label="left").agg(ohlc_dict).dropna()
     df["date"] = df.index
 
     return df

--- a/technical/util.py
+++ b/technical/util.py
@@ -3,6 +3,7 @@
 """
 from pandas import DataFrame, DatetimeIndex, merge, to_datetime, to_timedelta
 
+
 TICKER_INTERVAL_MINUTES = {
     "1m": 1,
     "5m": 5,

--- a/technical/util.py
+++ b/technical/util.py
@@ -3,7 +3,6 @@
 """
 from pandas import DataFrame, DatetimeIndex, merge, to_datetime, to_timedelta
 
-
 TICKER_INTERVAL_MINUTES = {
     "1m": 1,
     "5m": 5,
@@ -84,19 +83,25 @@ def resampled_merge(original, resampled, fill_na=True):
     if original_int < resampled_int:
         # Subtract "small" timeframe so merging is not delayed by 1 small candle.
         # Detailed explanation in https://github.com/freqtrade/freqtrade/issues/4073
-        resampled['date_merge'] = (
-            resampled["date"] + to_timedelta(resampled_int, 'm') - to_timedelta(original_int, 'm')
-            )
+        resampled["date_merge"] = (
+            resampled["date"] + to_timedelta(resampled_int, "m") - to_timedelta(original_int, "m")
+        )
     else:
-        raise ValueError("Tried to merge a faster timeframe to a slower timeframe."
-                         "Upsampling is not possible.")
+        raise ValueError(
+            "Tried to merge a faster timeframe to a slower timeframe." "Upsampling is not possible."
+        )
 
     # rename all the columns to the correct interval
     resampled.columns = [f"resample_{resampled_int}_{col}" for col in resampled.columns]
 
-    dataframe = merge(original, resampled, how="left",
-                      left_on='date', right_on=f'resample_{resampled_int}_date_merge')
-    dataframe = dataframe.drop(f'resample_{resampled_int}_date_merge', axis=1)
+    dataframe = merge(
+        original,
+        resampled,
+        how="left",
+        left_on="date",
+        right_on=f"resample_{resampled_int}_date_merge",
+    )
+    dataframe = dataframe.drop(f"resample_{resampled_int}_date_merge", axis=1)
 
     if fill_na:
         dataframe.fillna(method="ffill", inplace=True)

--- a/technical/util.py
+++ b/technical/util.py
@@ -69,7 +69,8 @@ def resample_to_interval(dataframe, interval):
 
 def resampled_merge(original, resampled, fill_na=True):
     """
-    this method merges a resampled dataset back into the orignal data set
+        this method merges a resampled dataset back into the orignal data set.
+        Resampled candle will match OHLC only if full timespan is available in original dataframe. 
 
     :param original: the original non resampled dataset
     :param resampled:  the resampled dataset

--- a/technical/util.py
+++ b/technical/util.py
@@ -45,11 +45,11 @@ def ticker_history_to_dataframe(ticker: list) -> DataFrame:
     return frame
 
 
-def resample_to_interval(dataframe, interval):
+def resample_to_interval(dataframe: DataFrame, interval):
     """
-        resamples the given dataframe to the desired interval.
-        Please be aware you need to upscale this to join the results
-        with the other dataframe
+    Resamples the given dataframe to the desired interval.
+    Please be aware you need to use resampled_merge to merge to another dataframe to
+    avoid lookahead bias
 
     :param dataframe: dataframe containing close/high/low/open/volume
     :param interval: to which ticker value in minutes would you like to resample it
@@ -61,16 +61,17 @@ def resample_to_interval(dataframe, interval):
     df = dataframe.copy()
     df = df.set_index(DatetimeIndex(df["date"]))
     ohlc_dict = {"open": "first", "high": "max", "low": "min", "close": "last", "volume": "sum"}
+    # Resample to "left" border as dates are candle open dates
     df = df.resample(str(interval) + "min", label="left").agg(ohlc_dict).dropna()
     df.reset_index(inplace=True)
 
     return df
 
 
-def resampled_merge(original, resampled, fill_na=True):
+def resampled_merge(original: DataFrame, resampled: DataFrame, fill_na=True):
     """
-        this method merges a resampled dataset back into the orignal data set.
-        Resampled candle will match OHLC only if full timespan is available in original dataframe.
+    Merges a resampled dataset back into the orignal data set.
+    Resampled candle will match OHLC only if full timespan is available in original dataframe.
 
     :param original: the original non resampled dataset
     :param resampled:  the resampled dataset
@@ -111,7 +112,7 @@ def resampled_merge(original, resampled, fill_na=True):
 
 def compute_interval(dataframe: DataFrame, exchange_interval=False):
     """
-        calculates the interval of the given dataframe for us
+    Calculates the interval of the given dataframe for us
     :param dataframe:
     :param exchange_interval: should we convert the result to an exchange interval or just a number
     :return:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,5 @@
 import json
+import pandas as pd
 
 from technical.indicators import chaikin_money_flow
 from technical.util import resample_to_interval, resampled_merge, ticker_history_to_dataframe
@@ -29,13 +30,27 @@ def test_resampled_merge(testdata_1m_btc):
     assert "resample_5_low" in merged
     assert "resample_5_high" in merged
 
-    assert "resample_5_date" not in merged
-    assert "resample_5_volume" not in merged
+    assert "resample_5_date" in merged
+    assert "resample_5_volume" in merged
     # Verify the assignment goes to the correct candle
     # If resampling to 5m, then the resampled value needs to be on the 5m candle.
-    assert sum(merged.loc[merged["date"] == "2017-11-14 22:54:00", "resample_5_close"].isna()) == 1
-    assert sum(merged.loc[merged["date"] == "2017-11-14 22:55:00", "resample_5_close"].isna()) == 0
-    assert sum(merged.loc[merged["date"] == "2017-11-14 22:56:00", "resample_5_close"].isna()) == 1
+    date = pd.to_datetime('2017-11-14 22:45:00', utc=True)
+    assert merged.loc[merged["date"] == "2017-11-14 22:48:00", "resample_5_date"].iloc[0] != date
+    # The 5m candle for 22:45 is available at 22:50,
+    # when both :49 1m and :45 5m candles close
+    assert merged.loc[merged["date"] == "2017-11-14 22:49:00", "resample_5_date"].iloc[0] == date
+    assert merged.loc[merged["date"] == "2017-11-14 22:50:00", "resample_5_date"].iloc[0] == date
+    assert merged.loc[merged["date"] == "2017-11-14 22:51:00", "resample_5_date"].iloc[0] == date
+    assert merged.loc[merged["date"] == "2017-11-14 22:52:00", "resample_5_date"].iloc[0] == date
+    assert merged.loc[merged["date"] == "2017-11-14 22:53:00", "resample_5_date"].iloc[0] == date
+    # The 5m candle for 22:50 is available at 22:54,
+    # when both :54 1m and :50 5m candles close
+    date = pd.to_datetime('2017-11-14 22:50:00', utc=True)
+    assert merged.loc[merged["date"] == "2017-11-14 22:54:00", "resample_5_date"].iloc[0] == date
+    assert merged.loc[merged["date"] == "2017-11-14 22:55:00", "resample_5_date"].iloc[0] == date
+    assert merged.loc[merged["date"] == "2017-11-14 22:56:00", "resample_5_date"].iloc[0] == date
+    assert merged.loc[merged["date"] == "2017-11-14 22:57:00", "resample_5_date"].iloc[0] == date
+    assert merged.loc[merged["date"] == "2017-11-14 22:58:00", "resample_5_date"].iloc[0] == date
 
 
 def test_resampled_merge_contains_indicator(testdata_1m_btc):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,5 @@
 import json
+
 import pandas as pd
 
 from technical.indicators import chaikin_money_flow
@@ -34,7 +35,7 @@ def test_resampled_merge(testdata_1m_btc):
     assert "resample_5_volume" in merged
     # Verify the assignment goes to the correct candle
     # If resampling to 5m, then the resampled value needs to be on the 5m candle.
-    date = pd.to_datetime('2017-11-14 22:45:00', utc=True)
+    date = pd.to_datetime("2017-11-14 22:45:00", utc=True)
     assert merged.loc[merged["date"] == "2017-11-14 22:48:00", "resample_5_date"].iloc[0] != date
     # The 5m candle for 22:45 is available at 22:50,
     # when both :49 1m and :45 5m candles close
@@ -45,7 +46,7 @@ def test_resampled_merge(testdata_1m_btc):
     assert merged.loc[merged["date"] == "2017-11-14 22:53:00", "resample_5_date"].iloc[0] == date
     # The 5m candle for 22:50 is available at 22:54,
     # when both :54 1m and :50 5m candles close
-    date = pd.to_datetime('2017-11-14 22:50:00', utc=True)
+    date = pd.to_datetime("2017-11-14 22:50:00", utc=True)
     assert merged.loc[merged["date"] == "2017-11-14 22:54:00", "resample_5_date"].iloc[0] == date
     assert merged.loc[merged["date"] == "2017-11-14 22:55:00", "resample_5_date"].iloc[0] == date
     assert merged.loc[merged["date"] == "2017-11-14 22:56:00", "resample_5_date"].iloc[0] == date


### PR DESCRIPTION
Hi!
This PR partially fix resampling logic.
Missing how to manage `resampled_merge` and how to align to `merge_informative_pair` behaviour (main repo).
Probably it will need a PR coordinated with the main repo.

Fixes #180