### PR TITLE
fix Ichimoku displacement on LS SSA SSB

### DIFF
--- a/technical/indicators/indicators.py
+++ b/technical/indicators/indicators.py
@@ -58,7 +58,7 @@ def ichimoku(
         + dataframe["low"].rolling(window=laggin_span).min()
     ) / 2
 
-    senkou_span_a = leading_senkou_span_a.shift(displacement -1)
+    senkou_span_a = leading_senkou_span_a.shift(displacement - 1)
 
     senkou_span_b = leading_senkou_span_b.shift(displacement - 1)
 

--- a/technical/indicators/indicators.py
+++ b/technical/indicators/indicators.py
@@ -58,11 +58,11 @@ def ichimoku(
         + dataframe["low"].rolling(window=laggin_span).min()
     ) / 2
 
-    senkou_span_a = leading_senkou_span_a.shift(displacement)
+    senkou_span_a = leading_senkou_span_a.shift(displacement -1)
 
-    senkou_span_b = leading_senkou_span_b.shift(displacement)
+    senkou_span_b = leading_senkou_span_b.shift(displacement - 1)
 
-    chikou_span = dataframe["close"].shift(-displacement)
+    chikou_span = dataframe["close"].shift(-displacement + 1)
 
     cloud_green = senkou_span_a > senkou_span_b
     cloud_red = senkou_span_b > senkou_span_a


### PR DESCRIPTION
intend to solve some displacement problems on ichimoku indicator :
all lines affected by displacement are not in good position.

lagging span is 1 candle before his real position, ssa and ssb are 1 candle after their real position

eg:
before 
![1-before](https://user-images.githubusercontent.com/1523359/148792130-c7f066a7-8393-4d74-995e-b30e8714a917.png)

real from tradingview
![2-real](https://user-images.githubusercontent.com/1523359/148792176-448726c9-af10-424d-8a02-1724033979df.png)

after fix
![3-after](https://user-images.githubusercontent.com/1523359/148792211-241af65f-b59e-45b0-a7fa-0e229e9119d1.png)

it will remains a bug when resample_merge an higher timeframe but it seems more related to resampled_merge() method