### PR TITLE
fix displacement on resampled_merge() method

### DIFF
--- a/technical/util.py
+++ b/technical/util.py
@@ -105,7 +105,7 @@ def resampled_merge(original: DataFrame, resampled: DataFrame, fill_na=True):
     dataframe = dataframe.drop(f"resample_{resampled_int}_date_merge", axis=1)
 
     if fill_na:
-        dataframe.fillna(method="ffill", inplace=True)
+        dataframe.fillna(method="bfill", inplace=True)
 
     return dataframe
 


### PR DESCRIPTION
attempt to fix some misplacement on resampled_merged dataframe:

as you can see method='ffill' give a 5 candle displacement of merged indicators in the future

in this example i resampled 4h df in 1day, market open/close at 1h UTC 
 
1 - before with ffill method, new merged value starts at 21h UTC and end at 17h UTC
![1-ffill](https://user-images.githubusercontent.com/1523359/148950610-a7e5e0af-9b34-4487-b4ba-d6379b64220b.png)
![2-ffill](https://user-images.githubusercontent.com/1523359/148950624-d0893e4e-c294-41ba-965f-c20c2ce9fd5d.png)

2 - after with bfill method new value starts at 1h UTC and end at 21h UTC
![1-bfill](https://user-images.githubusercontent.com/1523359/148950552-c75fe79b-f457-4be6-bbf1-a544a9bfc355.png)
![2-bfill](https://user-images.githubusercontent.com/1523359/148950654-027b19fe-facd-4379-b4ef-1361a1594ced.png)
