### PR TITLE
Fix missing pair of parentheses in cmf indicator.

### DIFF
--- a/technical/indicators/volume_indicators.py
+++ b/technical/indicators/volume_indicators.py
@@ -15,7 +15,7 @@ Volume indicators
 
 # Other Volume Indicator Functions
 def chaikin_money_flow(dataframe, period=21):
-    mfm = (dataframe["close"] - dataframe["low"]) - (dataframe["high"] - dataframe["close"]) / (
+    mfm = ((dataframe["close"] - dataframe["low"]) - (dataframe["high"] - dataframe["close"])) / (
         dataframe["high"] - dataframe["low"]
     )
     mfv = mfm * dataframe["volume"]


### PR DESCRIPTION
The current CMF indicator implementation has a bug due to a missing pair of parentheses and is producing incorrect results:

<img width="1281" height="155" alt="image" src="https://github.com/user-attachments/assets/febe134a-3c70-437d-ad48-665775b0a44c" />

The CMF indicator is supposed to produce results between -1 and 1. The fix in this pull request will correct the issue.